### PR TITLE
Syntax documentation section

### DIFF
--- a/ui/doc/index.jsx
+++ b/ui/doc/index.jsx
@@ -26,6 +26,8 @@ export default class Doc extends React.Component {
           {doc.name}
         </h2>
 
+        {this._renderSyntaxSection(doc.name, doc.params)}
+
         <section className='doc-section'>
           <h3 className='doc-subheader'>
             Description
@@ -48,6 +50,31 @@ export default class Doc extends React.Component {
     } else {
       return null
     }
+  }
+
+  _renderSyntaxSection(name, args) {
+    const argsString = (args || [])
+      .map((arg) => {
+        const spreadString = arg.variable ? '...' : ''
+        const defaultValueString = arg.defaultvalue !== undefined ? '=' + arg.defaultvalue : ''
+        const argString = spreadString + arg.name + defaultValueString
+        return arg.optional ? `[${argString}]` : argString
+      })
+      .join(', ')
+
+    return <section className='doc-section'>
+      <h3 className='doc-subheader'>
+        Syntax
+      </h3>
+
+      <Code
+        value={`${name}(${argsString})`}
+        options={{
+          readOnly: true,
+          mode: 'javascript'
+        }}
+      />
+    </section>
   }
 
   _renderArgumentsSection(args) {


### PR DESCRIPTION
This section is known as “Syntax” in MDN docs, e.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acos
and "Usage" in angular.js docs, e.g. https://docs.angularjs.org/api/ng/function/angular.isArray
Which name is better?