### PR TITLE
`render` returns null when component is empty

### DIFF
--- a/ui/doc/doc_arguments/index.jsx
+++ b/ui/doc/doc_arguments/index.jsx
@@ -6,7 +6,7 @@ export default class DocArguments extends React.Component {
   }
 
   render() {
-    if (!this.props.args) return
+    if (!this.props.args) return null
 
     return <section className='doc-section'>
       <h3 className='doc-subheader'>

--- a/ui/doc/index.jsx
+++ b/ui/doc/index.jsx
@@ -92,7 +92,7 @@ export default class Doc extends React.Component {
   }
 
   _renderExceptionsSection(exceptions) {
-    if (!exceptions) return
+    if (!exceptions) return null
 
     return <section className='doc-section'>
       <h3 className='doc-subheader'>
@@ -130,7 +130,7 @@ export default class Doc extends React.Component {
   }
 
   _renderExamplesSection(examples) {
-    if (!examples) return
+    if (!examples) return null
 
     return <section className='doc-section'>
       <h3 className='doc-subheader'>


### PR DESCRIPTION
Prevent this error
```
DocArguments.render(): A valid ReactComponent must be returned. You may have returned undefined, an array or some other invalid object.
```
when looking docs for functions without arguments (like `startOfToday`) by returning null when component DocArguments is empty:
https://facebook.github.io/react/blog/2014/07/17/react-v0.11.html#rendering-to-null