### PR TITLE
Fix docs rendering (closes #73, closes #74, closes #77)

### DIFF
--- a/app/ui/_lib/markdown/index.jsx
+++ b/app/ui/_lib/markdown/index.jsx
@@ -35,7 +35,7 @@ export default class Markdown extends React.Component {
         const extraAttrs = {}
         const extraChildren = []
 
-        if (/^h[1-6]$/.test(token.tagName)) {
+        if (/^h[2-6]$/.test(token.tagName)) {
           let headerLinkId = this._getUrlIdFromText(token)
           extraAttrs.id = headerLinkId
           extraChildren.push(<a

--- a/app/ui/_lib/markdown/index.jsx
+++ b/app/ui/_lib/markdown/index.jsx
@@ -41,6 +41,7 @@ export default class Markdown extends React.Component {
           extraChildren.push(<a
             href={`#${headerLinkId}`}
             className='doc-header_link'
+            key={`${index}-2`}
           >
               #
           </a>)
@@ -62,6 +63,7 @@ export default class Markdown extends React.Component {
         return <MarkdownCode
           value={token.content.trim()}
           language={token.language}
+          key={index}
         />
     }
   }

--- a/app/ui/docs/index.jsx
+++ b/app/ui/docs/index.jsx
@@ -103,7 +103,7 @@ export default class Docs extends React.Component {
           }
         )}
         onClick={this._openDoc.bind(this, doc.urlId)}
-        key={doc.id}
+        key={doc.urlId}
       >
         <div className='docs-item_content'>
           <h4 className='docs-item_header'>

--- a/app/ui/index.jsx
+++ b/app/ui/index.jsx
@@ -6,6 +6,7 @@ import classnames from 'classnames'
 import Features from 'app/ui/features'
 import Docs from 'app/ui/docs'
 import Doc from 'app/ui/doc'
+import docs from 'app/_lib/docs'
 
 export default class Ui extends React.Component {
   static propTypes = {
@@ -13,7 +14,7 @@ export default class Ui extends React.Component {
   }
 
   render () {
-    const isCollapsed = this.props.routeData.route.name !== 'home'
+    const isCollapsed = this._isCollapsed()
     const className = classnames('ui', {'is-collapsed': isCollapsed})
 
     return <div className={className}>
@@ -28,17 +29,39 @@ export default class Ui extends React.Component {
       <div className='ui-docs'>
         <Docs
           showLogo={isCollapsed}
-          currentId={this._currentDocId()}
+          currentId={this._currentDocsItemId()}
         />
       </div>
 
       <div className='ui-doc'>
-        <Doc docId={this._currentDocId()} />
+        <Doc docId={this._currentDocContentId()} />
       </div>
     </div>
   }
 
+  _currentDocContentId () {
+    return this._currentDocId() || this._firstDocId()
+  }
+
+  _currentDocsItemId () {
+    const currentDocId = this._currentDocId()
+
+    if (currentDocId) {
+      return currentDocId
+    } else if (this._isCollapsed()) {
+      return this._firstDocId()
+    }
+  }
+
   _currentDocId () {
     return this.props.routeData.params.docId
+  }
+
+  _firstDocId () {
+    return docs[Object.keys(docs)[0]][0].urlId
+  }
+
+  _isCollapsed () {
+    return this.props.routeData.route.name !== 'home'
   }
 }

--- a/app/ui/index.jsx
+++ b/app/ui/index.jsx
@@ -54,7 +54,8 @@ export default class Ui extends React.Component {
   }
 
   _currentDocId () {
-    return this.props.routeData.params.docId
+    const {docId} = this.props.routeData.params
+    return docId ? decodeURI(docId) : undefined
   }
 
   _firstDocId () {

--- a/app/ui/jsdoc/arguments/index.jsx
+++ b/app/ui/jsdoc/arguments/index.jsx
@@ -9,8 +9,9 @@ export default class JSDocArguments extends React.Component {
     if (!this.props.args) return null
 
     return <section>
-      <h2>
+      <h2 id='arguments'>
         Arguments
+        <a href='#arguments' className='doc-header_link'>#</a>
       </h2>
 
       <table>

--- a/app/ui/jsdoc/index.jsx
+++ b/app/ui/jsdoc/index.jsx
@@ -23,8 +23,9 @@ export default class JSDoc extends React.Component {
       </h1>
 
       <section>
-        <h2>
+        <h2 id='description'>
           Description
+          <a href='#description' className='doc-header_link'>#</a>
         </h2>
 
         <Markdown value={docContent.description} />
@@ -46,8 +47,9 @@ export default class JSDoc extends React.Component {
 
   _renderReturnsSection (returns) {
     return <section>
-      <h2>
+      <h2 id='returns'>
         Returns
+        <a href='#returns' className='doc-header_link'>#</a>
       </h2>
 
       <table>
@@ -82,8 +84,9 @@ export default class JSDoc extends React.Component {
     if (!exceptions) return
 
     return <section>
-      <h2>
+      <h2 id='exceptions'>
         Exceptions
+        <a href='#exceptions' className='doc-header_link'>#</a>
       </h2>
 
       <table>
@@ -120,8 +123,9 @@ export default class JSDoc extends React.Component {
     if (!examples) return
 
     return <section>
-      <h2>
+      <h2 id='examples'>
         Examples
+        <a href='#examples' className='doc-header_link'>#</a>
       </h2>
 
       <div>

--- a/app/ui/jsdoc/syntax/index.jsx
+++ b/app/ui/jsdoc/syntax/index.jsx
@@ -13,8 +13,9 @@ export default class JSDocSyntax extends React.Component {
     const argsString = this._calculateArgsString(args)
 
     return <section>
-      <h2>
+      <h2 id='syntax'>
         Syntax
+        <a href='#syntax' className='doc-header_link'>#</a>
       </h2>
 
       <Code

--- a/app/ui/jsdoc/usage/index.jsx
+++ b/app/ui/jsdoc/usage/index.jsx
@@ -24,8 +24,9 @@ export default class JSDocUsage extends React.Component {
 
   render () {
     return <section>
-      <h2>
+      <h2 id='usage'>
         Usage
+        <a href='#usage' className='doc-header_link'>#</a>
       </h2>
 
       <ul className='jsdoc_usage-options'>


### PR DESCRIPTION
- Disable header link for h1
- Add header links to JSDoc docs
- Show first doc when /docs is opened
- Fix React's key warnings
- Decode doc id on reading from route data
