### PR TITLE
fix(TypeError): safe get for docsKey property in fetchDocs

### DIFF
--- a/app/acts/versions/index.js
+++ b/app/acts/versions/index.js
@@ -68,7 +68,14 @@ export function onVersionChange (state, prevState) {
 }
 
 function fetchDocs (state) {
-  Either.of(tag => versions => ({ tag, docsKey: versions.get(tag).docsKey }))
+  Either.of(tag => versions => {
+    const versionsTag = versions.get(tag)
+    const docsKey = versionsTag ? versionsTag.docsKey : ''
+    return {
+      tag,
+      docsKey
+    }
+  })
     .ap(getSelectedVersionTag(state))
     .ap(state.versions)
     .map(({ tag, docsKey }) => {


### PR DESCRIPTION
This is a minor fix for a TypeError on an undefined property lookup. It's not clear to me if this is something that can really occur, but I noticed it when looking into [date-fns issue 701](https://github.com/date-fns/date-fns/issues/701). 

The issue contains a link to https://date-fns.org/docs which seems unlikely for people to navigate too, but when clicking the link we can see the following `Uncaught TypeError` in the console. This PR simply seeks to resolve the change of that TypeError being thrown.

![image](https://user-images.githubusercontent.com/5889417/37530714-36561b74-2908-11e8-9c38-1c23bfb643e4.png)
