### PR TITLE
Update usage for v2 (see #1031 on date-fns repo)

### DIFF
--- a/app/ui/home/examples/index.jsx
+++ b/app/ui/home/examples/index.jsx
@@ -11,7 +11,7 @@ const examples = [
     code: `
 import { format, formatDistance, formatRelative, subDays } from 'date-fns'
 
-format(new Date(), '[Today is a] dddd')
+format(new Date(), "'Today is a' iiii")
 //=> "Today is a ${
       [
         'Sunday',


### PR DESCRIPTION
The indicated usage is no longer correct for v2 as of `2.0.0-alpha.8`. This corrects the usage to use the updated formatting.