### PR TITLE
Update home page examples to more accurately reflect output

### DIFF
--- a/app/ui/home/examples/index.jsx
+++ b/app/ui/home/examples/index.jsx
@@ -24,11 +24,11 @@ format(new Date(), "'Today is a' iiii")
       ][new Date().getDay()]
     }"
 
-formatDistance(subDays(new Date(), 3), new Date())
+formatDistance(subDays(new Date(), 3), new Date(), { addSuffix: true })
 //=> "3 days ago"
 
 formatRelative(subDays(new Date(), 3), new Date())
-//=> "last Friday at 7:26 p.m."
+//=> "last Friday at 7:26 PM"
 `.trim()
   },
   {


### PR DESCRIPTION
I noticed on the home page the examples aren't exactly portraying what the correct output should be: 
![image](https://user-images.githubusercontent.com/7097976/66095774-a7aebd00-e54d-11e9-8362-77d1650d7228.png)

I did a bit of testing to see what the actual output is supposed to be:
```
> formatDistance(subDays(new Date(), 3), new Date())
'3 days'
> formatDistance(subDays(new Date(), 3), new Date(), { addSuffix: true })
'3 days ago'
> formatRelative(subDays(new Date(), 3), new Date())
'last Sunday at 7:43 PM'
```

So the two changes I made are:
1. In order to display the `ago` text at the end, `formatDistance` needs `{ addSuffix: true }`. Another possible solve is to just remove the `ago` text in the comment. I can change that if desired, just let me know.
1. `formatRelative` doesn't display `p.m.`, it displays `PM`.