### PR TITLE
Fix header z-index to sit higher than <pre>

### DIFF
--- a/app/ui/docs/nav_bar/style.css
+++ b/app/ui/docs/nav_bar/style.css
@@ -5,7 +5,7 @@
   background-size: cover;
   background-position: top center;
   position: fixed;
-  z-index: 100;
+  z-index: 300;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
I wasn't able to test this locally as I couldn't get set up. But this should do the trick - the CodeMirror pre tags are all sitting higher than the header.

<img width="600" alt="screenshot" src="https://user-images.githubusercontent.com/17421347/97647235-f8be0880-1a0e-11eb-8f44-67761b81799d.png">

Fixes https://github.com/date-fns/date-fns/issues/2063