### PR TITLE
Make headers in the docs sidebar sticky

### DIFF
--- a/src/ui/screens/Docs/Finder/style.css
+++ b/src/ui/screens/Docs/Finder/style.css
@@ -77,6 +77,9 @@
   color: #4a3142;
   padding: 0.5rem 1rem;
   border-bottom: 1px solid #e6e0e6;
+  position: sticky;
+  top: 0;
+  background-color: #fffbf5;
 }
 
 .Item {


### PR DESCRIPTION
Not tested locally, but I edited the CSS of the live website and got this:

<img src="https://user-images.githubusercontent.com/25517624/143940173-6ae63fe6-85ec-417a-90e0-112159de150a.gif" width="427">
