### PR TITLE
feat: support v4 console access

### DIFF
--- a/src/server/template/index.ts
+++ b/src/server/template/index.ts
@@ -78,8 +78,9 @@ export const template = ({ body }: Params = {}) =>
       const CODE_STYLE = 'font-size: 14px; font-family: monospace;'
 
       async function init(dirtyVersion) {
-        const version = dirtyVersion && dirtyVersion.replace(/^v/, '') || '2.29.3'
-        const url = 'https://unpkg.com/date-fns' + (version ? '@' + version : '') + '/esm/index.js'
+        const version = dirtyVersion && dirtyVersion.replace(/^v/, '') || '4.1.0'
+        const indexFile = version[0] === '4' ? '/index.js' : '/esm/index.js'
+        const url = 'https://unpkg.com/date-fns' + (version ? '@' + version : '') + indexFile
         try {
           const dateFns = await import(url)
           window._ = dateFns


### PR DESCRIPTION
## Problem
The latest version (4.1.0 at the time of this PR) cannot be loaded in the console via `init("v4.1.0")` 



## Solution
Before: the unkpg url would be appended with `/esm/index.js` regardless of the version
After: if the version starts with 4, append `/index.js` instead
- same behavior for all versions that do not start with 4

Also defaults `init()` to use the current latest version.

Tested in Chrome locally

<img width="732" alt="image" src="https://github.com/user-attachments/assets/8fb9aba0-b706-4bf8-bf5d-9d76c8b8e51d">

This should partially resolve https://github.com/date-fns/date-fns.org/issues/222

only partial because V3 is not supported

Alternatively, unpkg mentions:
> If you omit the file path (i.e. use a “bare” URL), unpkg will serve the file specified by the unpkg field in package.json, or fall back to main.