### PR TITLE
Fix broken date-fns console demo for v3.0.0 and later

### DIFF
--- a/src/server/template/index.ts
+++ b/src/server/template/index.ts
@@ -78,10 +78,14 @@ export const template = ({ body }: Params = {}) =>
       const CODE_STYLE = 'font-size: 14px; font-family: monospace;'
 
       async function init(dirtyVersion) {
-        const version = dirtyVersion && dirtyVersion.replace(/^v/, '') || '2.29.3'
-        const url = 'https://unpkg.com/date-fns' + (version ? '@' + version : '') + '/esm/index.js'
+        const version = dirtyVersion && dirtyVersion.replace(/^v/, '') || '4.1.0'
+        const url = 'https://unpkg.com/date-fns' + (version ? '@' + version : '')
+        const packageUrl = url + '/package.json'
         try {
-          const dateFns = await import(url)
+          const response = await fetch(packageUrl)
+          const packageJson = await response.json()
+          const indexUrl = url + '/' + packageJson.module
+          const dateFns = await import(indexUrl)
           window._ = dateFns
           window.dateFns = dateFns
 
@@ -98,7 +102,7 @@ export const template = ({ body }: Params = {}) =>
 
       console.log(
         '%c( ⩗) date-fns console\\n' +
-          '%cRun %cinit()%c or %cinit("v2.16.1" /* version */)\\n' +
+          '%cRun %cinit()%c or %cinit("v4.1.0" /* version */)\\n' +
           '%cto make date-fns functions available in console.',
         HEADER_STYLE, MESSAGE_STYLE, CODE_STYLE, MESSAGE_STYLE, CODE_STYLE, MESSAGE_STYLE,
       )


### PR DESCRIPTION
@kossnocorp 

Closes  #215, #222, https://github.com/date-fns/date-fns/issues/3405, https://github.com/date-fns/date-fns/issues/4085

The developer console demo of date-fns is currently broken for all versions v3 or higher.
This should be a sustainable solution for the bug, supporting all versions of date-fns. It reads the `module` field of the versions `package.json` to get the correct index file.

See also PRs #225, #229, both incomplete solutions to this problem