### PR TITLE
Add Dark/Light Theme Toggler for the Documentation Website

### DIFF
--- a/src/ui/components/Code/styles.css.ts
+++ b/src/ui/components/Code/styles.css.ts
@@ -14,8 +14,8 @@ export const code = style({
     display: 'none',
   },
 
-  '@media': {
-    '(prefers-color-scheme: dark)': {
+  selectors: {
+    '[data-theme="dark"] &, .dark-theme &': {
       color: '#c5c4c2',
       backgroundColor: '#12000a',
     },
@@ -29,8 +29,8 @@ export const pre = style({
   padding: '.25rem .5rem',
   borderRadius: '4px',
 
-  '@media': {
-    '(prefers-color-scheme: dark)': {
+  selectors: {
+    '[data-theme="dark"] &, .dark-theme &': {
       backgroundColor: '#12000a',
       borderColor: '#2c1622',
     },

--- a/src/ui/components/Code/theme.css
+++ b/src/ui/components/Code/theme.css
@@ -147,23 +147,54 @@ pre[class*='language-'] {
 }
 
 @media (prefers-color-scheme: dark) {
-  .token.keyword {
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.keyword {
     color: #e170be;
   }
 
-  .token.number,
-  .token.string,
-  .token.property,
-  .token.tag,
-  .token.boolean,
-  .token.constant,
-  .token.symbol,
-  .token.deleted {
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.number,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.string,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.property,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.tag,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.boolean,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.constant,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.symbol,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.deleted {
     color: #cfc0c8;
   }
 
-  .token.function,
-  .token.class-name {
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.function,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) .token.class-name {
     color: #db8e66;
   }
+}
+
+[data-theme='dark'] .token.keyword,
+.dark-theme .token.keyword {
+  color: #e170be;
+}
+
+[data-theme='dark'] .token.number,
+[data-theme='dark'] .token.string,
+[data-theme='dark'] .token.property,
+[data-theme='dark'] .token.tag,
+[data-theme='dark'] .token.boolean,
+[data-theme='dark'] .token.constant,
+[data-theme='dark'] .token.symbol,
+[data-theme='dark'] .token.deleted,
+.dark-theme .token.number,
+.dark-theme .token.string,
+.dark-theme .token.property,
+.dark-theme .token.tag,
+.dark-theme .token.boolean,
+.dark-theme .token.constant,
+.dark-theme .token.symbol,
+.dark-theme .token.deleted {
+  color: #cfc0c8;
+}
+
+[data-theme='dark'] .token.function,
+[data-theme='dark'] .token.class-name,
+.dark-theme .token.function,
+.dark-theme .token.class-name {
+  color: #db8e66;
 }

--- a/src/ui/components/ThemeToggle/index.tsx
+++ b/src/ui/components/ThemeToggle/index.tsx
@@ -1,0 +1,25 @@
+import { h, FunctionComponent } from 'preact'
+import { useTheme } from '~/ui/hooks/useTheme'
+import * as styles from './styles.css'
+
+export const ThemeToggle: FunctionComponent = () => {
+  const { theme, toggleTheme, effectiveTheme } = useTheme()
+
+  return (
+    <button
+      class={styles.toggle}
+      onClick={toggleTheme}
+      aria-label={`Switch to ${effectiveTheme === 'dark' ? 'light' : 'dark'} theme`}
+      title={`Current theme: ${effectiveTheme}. Click to switch to ${
+        effectiveTheme === 'dark' ? 'light' : 'dark'
+      }`}
+    >
+      {effectiveTheme === 'dark' ? (
+        <span class={styles.icon}>☀️</span>
+      ) : (
+        <span class={styles.icon}>🌙</span>
+      )}
+    </button>
+  )
+}
+

--- a/src/ui/components/ThemeToggle/styles.css.ts
+++ b/src/ui/components/ThemeToggle/styles.css.ts
@@ -1,0 +1,37 @@
+import { style } from '@vanilla-extract/css'
+
+export const toggle = style({
+  background: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  padding: '0.25rem 0.5rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: '1.2rem',
+  lineHeight: '1',
+  color: '#ffe9c9',
+  transition: 'opacity 0.2s ease',
+  marginLeft: '0.5rem',
+
+  ':hover': {
+    opacity: 0.8,
+  },
+
+  ':active': {
+    opacity: 0.6,
+  },
+
+  ':focus': {
+    outline: '2px solid #ffe9c9',
+    outlineOffset: '2px',
+    borderRadius: '2px',
+  },
+})
+
+export const icon = style({
+  display: 'inline-block',
+  fontSize: '1.1rem',
+  lineHeight: '1',
+})
+

--- a/src/ui/global.css
+++ b/src/ui/global.css
@@ -49,24 +49,59 @@ code:after {
   --color-tooltip-canvas: #280027;
   --color-tooltip-ink: #fff5ff;
   --icon-color: #770c5699;
+  
+  /* Theme variables */
+  --bg-primary: #fffdf9;
+  --bg-code: #faf6f0;
+  --text-primary: black;
+  --text-code: inherit;
+}
+
+:root[data-theme='dark'],
+:root.dark-theme {
+  color-scheme: dark;
+  --color-tooltip-canvas: #280027;
+  --color-tooltip-ink: #fff5ff;
+  --icon-color: #585056;
+  --bg-primary: #12020a;
+  --bg-code: #1e0814;
+  --text-primary: white;
+  --text-code: #c5c4c2;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) {
     color-scheme: dark;
     --icon-color: #585056;
+    --bg-primary: #12020a;
+    --bg-code: #1e0814;
+    --text-primary: white;
+    --text-code: #c5c4c2;
   }
 
-  code {
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) code {
     background-color: #1e0814;
     color: #c5c4c2;
   }
 
-  body,
-  input,
-  select,
-  textarea,
-  button {
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) body,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) input,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) select,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) textarea,
+  :root:not([data-theme]):not(.light-theme):not(.dark-theme) button {
     color: white;
   }
+}
+
+code {
+  background-color: var(--bg-code);
+  color: var(--text-code);
+}
+
+body,
+input,
+select,
+textarea,
+button {
+  color: var(--text-primary);
 }

--- a/src/ui/hooks/useTheme/index.tsx
+++ b/src/ui/hooks/useTheme/index.tsx
@@ -1,0 +1,87 @@
+import { useState, useEffect } from 'preact/hooks'
+
+export type Theme = 'light' | 'dark' | 'auto'
+
+const THEME_STORAGE_KEY = 'date-fns-theme'
+
+/**
+ * Gets the initial theme from localStorage or system preference
+ */
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'auto'
+  
+  const stored = localStorage.getItem(THEME_STORAGE_KEY) as Theme | null
+  if (stored && ['light', 'dark', 'auto'].includes(stored)) {
+    return stored
+  }
+  return 'auto'
+}
+
+/**
+ * Gets the effective theme (resolves 'auto' to 'light' or 'dark')
+ */
+function getEffectiveTheme(theme: Theme): 'light' | 'dark' {
+  if (theme === 'auto') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+  }
+  return theme
+}
+
+/**
+ * Applies the theme to the document
+ */
+function applyTheme(theme: Theme) {
+  const effectiveTheme = getEffectiveTheme(theme)
+  document.documentElement.setAttribute('data-theme', effectiveTheme)
+  
+  if (effectiveTheme === 'dark') {
+    document.documentElement.classList.add('dark-theme')
+    document.documentElement.classList.remove('light-theme')
+  } else {
+    document.documentElement.classList.add('light-theme')
+    document.documentElement.classList.remove('dark-theme')
+  }
+}
+
+/**
+ * Hook to manage theme state with localStorage persistence
+ */
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme)
+
+  useEffect(() => {
+    // Apply initial theme
+    applyTheme(theme)
+
+    // Listen for system theme changes when in auto mode
+    if (theme === 'auto') {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      const handleChange = () => {
+        applyTheme('auto')
+      }
+      mediaQuery.addEventListener('change', handleChange)
+      return () => mediaQuery.removeEventListener('change', handleChange)
+    }
+  }, [theme])
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme)
+    localStorage.setItem(THEME_STORAGE_KEY, newTheme)
+    applyTheme(newTheme)
+  }
+
+  const toggleTheme = () => {
+    const effectiveTheme = getEffectiveTheme(theme)
+    setTheme(effectiveTheme === 'dark' ? 'light' : 'dark')
+  }
+
+  return {
+    theme,
+    setTheme,
+    toggleTheme,
+    effectiveTheme: getEffectiveTheme(theme),
+  }
+}
+

--- a/src/ui/screens/Docs/NavBar/index.tsx
+++ b/src/ui/screens/Docs/NavBar/index.tsx
@@ -5,6 +5,7 @@ import { defaultSubmodule } from '@date-fns/docs/consts'
 import type { DateFnsDocs } from '@date-fns/docs/types'
 import { VersionSelector } from './VersionSelector'
 import { SubmoduleSelector } from './SubmoduleSelector'
+import { ThemeToggle } from '~/ui/components/ThemeToggle'
 import * as styles from './styles.css'
 
 interface Props {
@@ -61,7 +62,7 @@ export const NavBar: FunctionComponent<Props> = ({
             </a>
           </div>
 
-          <div>
+          <div class={styles.rightSection}>
             <VersionSelector
               selectedVersion={selectedVersion}
               latestVersion={latestVersion}
@@ -76,6 +77,8 @@ export const NavBar: FunctionComponent<Props> = ({
               selectedVersion={selectedVersion}
               submodules={submodules}
             />
+
+            <ThemeToggle />
           </div>
         </div>
       </div>

--- a/src/ui/screens/Docs/NavBar/styles.css.ts
+++ b/src/ui/screens/Docs/NavBar/styles.css.ts
@@ -124,6 +124,11 @@ export const menuIcon = style({
   },
 })
 
+export const rightSection = style({
+  display: 'flex',
+  alignItems: 'center',
+})
+
 globalStyle(`${menuIcon} img`, {
   width: '18px',
 })

--- a/src/ui/screens/Docs/styles.css.ts
+++ b/src/ui/screens/Docs/styles.css.ts
@@ -4,13 +4,7 @@ export const screen = style({
   height: '100%',
   width: '100%',
   overflowY: 'scroll',
-  background: '#fffdf9',
-
-  '@media': {
-    '(prefers-color-scheme: dark)': {
-      backgroundColor: '#12020a',
-    },
-  },
+  background: 'var(--bg-primary)',
 })
 
 export const content = style({

--- a/src/web/init.ts
+++ b/src/web/init.ts
@@ -2,5 +2,34 @@ import { initializeApp } from 'firebase/app'
 import { CONFIG, SENTRY_URL } from '~/constants'
 import { initSentry } from '~/utils/sentry'
 
+// Initialize theme before rendering to prevent flash
+function initTheme() {
+  const THEME_STORAGE_KEY = 'date-fns-theme'
+  const stored = localStorage.getItem(THEME_STORAGE_KEY)
+  let theme: 'light' | 'dark' = 'light'
+  
+  if (stored === 'dark') {
+    theme = 'dark'
+  } else if (stored === 'light') {
+    theme = 'light'
+  } else {
+    // Auto mode - use system preference
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light'
+  }
+  
+  document.documentElement.setAttribute('data-theme', theme)
+  if (theme === 'dark') {
+    document.documentElement.classList.add('dark-theme')
+    document.documentElement.classList.remove('light-theme')
+  } else {
+    document.documentElement.classList.add('light-theme')
+    document.documentElement.classList.remove('dark-theme')
+  }
+}
+
+initTheme()
+
 initializeApp(CONFIG.firebaseApp)
 initSentry(SENTRY_URL)


### PR DESCRIPTION
## Description

This PR implements a dark/light theme toggler for the date-fns documentation website as requested in [issue #4091](https://github.com/date-fns/date-fns/issues/4091).

## Changes

- Added `ThemeToggle` component with sun/moon icons in the navbar
- Implemented `useTheme` hook with localStorage persistence
- Added CSS variables for theme colors
- Updated global styles to support dark/light themes
- Updated Code component styles for theme support
- Added theme initialization in `init.ts` to prevent FOUC (Flash of Unstyled Content)
- Respects system preference (`prefers-color-scheme`) by default
- Allows manual override via toggle button

## Features

- **Theme Toggle Button**: Located in the top-right corner of the navbar with sun/moon icons
- **localStorage Persistence**: User's theme preference is saved and restored on page load
- **System Preference Support**: Automatically detects and respects system dark/light mode preference
- **Manual Override**: Users can manually toggle between light and dark themes
- **Accessibility**: Includes ARIA labels and keyboard support
- **No Flash**: Theme is applied immediately on page load to prevent FOUC

## Testing

- All existing functionality preserved
- Theme persists across page reloads
- System preference detection works correctly
- Manual toggle works as expected
- Code blocks and syntax highlighting support dark mode

Closes #4091